### PR TITLE
score best match rather than first match; other odds and ends

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,9 +52,10 @@ All scores fall between a range of 0.0 (no match) to 1.0 (perfect match).
 
 * More tests
 * Consider tweaking the scores for "trailing" characters
-* Some abbreviations are capable of yielding multiple scores.  Return the
-  highest score instead of just the first.
-* See if it's possible to tune the performance further.
+* Improve implementation of highest score matching (LiquidMetal
+  currently returns the highest scoring match for an abbreviation,
+  but is inefficient)
+* See if it's possible to tune the performance further
 
 ## Author
 

--- a/liquidmetal.js
+++ b/liquidmetal.js
@@ -21,6 +21,9 @@ var LiquidMetal = (function() {
   var WORD_SEPARATORS = [" ", "\t", "_", "-"];
 
   return {
+    lastScore: null,
+    lastScoreArray: null,
+
     score: function(string, abbrev) {
       // Short circuits
       if (abbrev.length === 0) return SCORE_TRAILING;
@@ -35,7 +38,12 @@ var LiquidMetal = (function() {
       // so perfect match score = 1
       var sum = 0.0;
       for (var i = 0; i < scores.length; i++) { sum += scores[i]; }
-      return (sum / scores.length);
+      var overall_score = sum / scores.length;
+
+      // record overall score & score array, return overall score
+      this.lastScore = overall_score;
+      this.lastScoreArray = scores;
+      return overall_score;
     },
 
     buildScoreArray: function(string, abbrev) {

--- a/liquidmetal.js
+++ b/liquidmetal.js
@@ -21,37 +21,37 @@ var LiquidMetal = (function() {
   var WORD_SEPARATORS = [" ", "\t", "_", "-"];
 
   return {
-    score: function(string, abbreviation) {
+    score: function(string, abbrev) {
       // Short circuits
-      if (abbreviation.length === 0) return SCORE_TRAILING;
-      if (abbreviation.length > string.length) return SCORE_NO_MATCH;
+      if (abbrev.length === 0) return SCORE_TRAILING;
+      if (abbrev.length > string.length) return SCORE_NO_MATCH;
 
-      var scores = this.buildScoreArray(string, abbreviation);
+      var scores = this.buildScoreArray(string, abbrev);
 
       // complete miss:
-      if ( scores === false )  return 0;
+      if (scores === false) return 0;
 
+      // sum per-character score for overall score, normalize by string length
+      // so perfect match score = 1
       var sum = 0.0;
-      for (var i = 0; i < scores.length; i++) {
-        sum += scores[i];
-      }
-
+      for (var i = 0; i < scores.length; i++) { sum += scores[i]; }
       return (sum / scores.length);
     },
 
-    buildScoreArray: function(string, abbreviation) {
+    buildScoreArray: function(string, abbrev) {
       var scores = new Array(string.length);
-      var lower = string.toLowerCase();
-      var chars = abbreviation.toLowerCase();
+      var search = string.toLowerCase();
+      abbrev = abbrev.toLowerCase();
 
       var lastIndex = -1;
       var started = false;
-      for (var i = 0; i < chars.length; i++) {
-        var c = chars[i];
-        var index = lower.indexOf(c, lastIndex+1);
+      // score each match according to context
+      for (var i = 0; i < abbrev.length; i++) {
+        var c = abbrev[i];
+        var index = search.indexOf(c, lastIndex+1);
 
         if (index === -1) return false; // signal no match
-        if (index === 0) started = true;
+        if (index === 0) started = true; // flag abbreviation at start of string
 
         if (isNewWord(string, index)) {
           scores[index-1] = 1;
@@ -68,6 +68,7 @@ var LiquidMetal = (function() {
         lastIndex = index;
       }
 
+      // score remaining string as trailing characters
       var trailingScore = started ? SCORE_TRAILING_BUT_STARTED : SCORE_TRAILING;
       fillArray(scores, trailingScore, lastIndex+1, scores.length);
       return scores;

--- a/liquidmetal.js
+++ b/liquidmetal.js
@@ -25,61 +25,82 @@ var LiquidMetal = (function() {
     lastScoreArray: null,
 
     score: function(string, abbrev) {
-      // Short circuits
+      // short circuits
       if (abbrev.length === 0) return SCORE_TRAILING;
       if (abbrev.length > string.length) return SCORE_NO_MATCH;
 
-      var scores = this.buildScoreArray(string, abbrev);
-
-      // complete miss:
-      if (scores === false) return 0;
-
-      // sum per-character score for overall score, normalize by string length
-      // so perfect match score = 1
-      var sum = 0.0;
-      for (var i = 0; i < scores.length; i++) { sum += scores[i]; }
-      var overall_score = sum / scores.length;
-
-      // record overall score & score array, return overall score
-      this.lastScore = overall_score;
-      this.lastScoreArray = scores;
-      return overall_score;
-    },
-
-    buildScoreArray: function(string, abbrev) {
-      var scores = new Array(string.length);
+      // match & score all
+      var allScores = [];
       var search = string.toLowerCase();
       abbrev = abbrev.toLowerCase();
+      this._scoreAll(string, search, abbrev, -1, 0, [], allScores);
 
-      var lastIndex = -1;
-      var started = false;
-      // score each match according to context
-      for (var i = 0; i < abbrev.length; i++) {
-        var c = abbrev[i];
-        var index = search.indexOf(c, lastIndex+1);
+      // complete miss
+      if (!allScores.length) return 0;
 
-        if (index === -1) return false; // signal no match
-        if (index === 0) started = true; // flag abbreviation at start of string
-
-        if (isNewWord(string, index)) {
-          scores[index-1] = 1;
-          fillArray(scores, SCORE_BUFFER, lastIndex+1, index-1);
+      // sum per-character scores into overall scores,
+      // selecting the maximum score
+      var maxScore = 0.0, maxArray = [];
+      for (var i = 0; i < allScores.length; i++) {
+        var scores = allScores[i];
+        var scoreSum = 0.0;
+        for (var j = 0; j < string.length; j++) { scoreSum += scores[j]; }
+        if (scoreSum > maxScore) {
+          maxScore = scoreSum;
+          maxArray = scores;
         }
-        else if (isUpperCase(string, index)) {
-          fillArray(scores, SCORE_BUFFER, lastIndex+1, index);
-        }
-        else {
-          fillArray(scores, SCORE_NO_MATCH, lastIndex+1, index);
-        }
-
-        scores[index] = SCORE_MATCH;
-        lastIndex = index;
       }
 
-      // score remaining string as trailing characters
-      var trailingScore = started ? SCORE_TRAILING_BUT_STARTED : SCORE_TRAILING;
-      fillArray(scores, trailingScore, lastIndex+1, scores.length);
-      return scores;
+      // normalize max score by string length
+      // s. t. the perfect match score = 1
+      maxScore /= string.length;
+
+      // record maximum score & score array, return
+      this.lastScore = maxScore;
+      this.lastScoreArray = maxArray;
+      return maxScore;
+    },
+
+    _scoreAll: function(string, search, abbrev, searchIndex, abbrIndex, scores, allScores) {
+      // save completed match scores at end of search
+      if (abbrIndex == abbrev.length) {
+        // add trailing score for the remainder of the match
+        var started = (search[0] == abbrev[0]);
+        var trailScore = started ? SCORE_TRAILING_BUT_STARTED : SCORE_TRAILING;
+        fillArray(scores, trailScore, scores.length, string.length);
+        // save score clone (since reference is persisted in scores)
+        allScores.push(scores.slice(0));
+        return;
+      }
+
+      // consume current char to match
+      var c = abbrev[abbrIndex];
+      abbrIndex++;
+
+      // cancel match if a character is missing
+      var index = search.indexOf(c, searchIndex);
+      if (index == -1) return;
+
+      // match all instances of the abbreviaton char
+      var scoreIndex = searchIndex; // score section to update
+      while ((index = search.indexOf(c, searchIndex+1)) != -1) {
+        // score this match according to context
+        if (isNewWord(string, index)) {
+          scores[index-1] = 1;
+          fillArray(scores, SCORE_BUFFER, scoreIndex+1, index-1);
+        }
+        else if (isUpperCase(string, index)) {
+          fillArray(scores, SCORE_BUFFER, scoreIndex+1, index);
+        }
+        else {
+          fillArray(scores, SCORE_NO_MATCH, scoreIndex+1, index);
+        }
+        scores[index] = SCORE_MATCH;
+
+        // consume matched string and continue search
+        searchIndex = index;
+        this._scoreAll(string, search, abbrev, searchIndex, abbrIndex, scores, allScores);
+      }
     }
   };
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
     var expectedScore = Math.round(sum / charScores.length * 1000) / 1000;
 
     var score = LiquidMetal.score(string, abbreviation);
-    var scoreArray = LiquidMetal.buildScoreArray(string, abbreviation);
+    var scoreArray = LiquidMetal.lastScoreArray;
     var roundedScore = Math.round(score*1000)/1000;
 
     var pass = (expectedScore == roundedScore);

--- a/test/tests.js
+++ b/test/tests.js
@@ -58,4 +58,5 @@ $(document).ready(function() {
   shouldScore([b,b,b,m,m,t,t], "Foo Bar", "b");
   shouldScore([n,m,m,n,n,m,m], "Foo Bar", "ooar");
   shouldScore([n,n,n,n,n,n,n], "Foo Bar", "bab");
+  shouldScore([b,b,b,b,b,m,m,b,b,m,m,t,t,t],  "gnu's Not Unix",  "nu");
 });


### PR DESCRIPTION
Rather than score the first match of the abbreviation, this implementation evaluates all matches and picks the one with the highest score. I will be the first to admit that it is not efficient in how it currently does so, though neither is it totally braindead.

Performance in ops/sec drop an order of magnitude. This is still 10,000s of ops/sec, but obviously a big hit. If you would rather wait for a more efficient implementation to merge, let me know. I know what next steps to take, but might not come back to this really soon.

Thanks again for releasing this project.
